### PR TITLE
few insecure fixes

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -77,13 +77,13 @@ class enrol_notificationeabc_observer
                 }
             }
             if (!empty($enrol) && $instanceenabled) {
-                $activeunenrolalert = $enrol->customint4;
+                $activeunenrolalert = $enrol->customint2;
             }
 
             if ($activeglobal == 1 && $activeunenrolalert == 1) {
-                $notificationeabc->enviarmail($user, $course, 2);
+                $notificationeabc->send_email($user, $course, 2);
             } else if (!empty($enrol) && !empty($activeunenrolalert) && $instanceenabled) {
-                $notificationeabc->enviarmail($user, $course, 2);
+                $notificationeabc->send_email($user, $course, 2);
             }
         }
     }
@@ -127,13 +127,13 @@ class enrol_notificationeabc_observer
                 }
             }
             if (!empty($enrol) && $instanceenabled) {
-                $activeenrolupdatedalert = $enrol->customint5;
+                $activeenrolupdatedalert = $enrol->customint3;
             }
 
             if ($activeglobal == 1 && $activeenrolupdatedalert == 1) {
-                $notificationeabc->enviarmail($user, $course, 3);
+                $notificationeabc->send_email($user, $course, 3);
             } else if (!empty($enrol) && !empty($activeenrolupdatedalert) && $instanceenabled) {
-                $notificationeabc->enviarmail($user, $course, 3);
+                $notificationeabc->send_email($user, $course, 3);
             }
         }
     }
@@ -160,7 +160,7 @@ class enrol_notificationeabc_observer
 
             $notificationeabc = new enrol_notificationeabc_plugin();
 
-            $activeglobal = $notificationeabc->get_config('activarglobal');
+            $activeglobal = $notificationeabc->get_config('activarglobalenrolalert');
             $activeenrolalert = $notificationeabc->get_config('activeenrolalert');
 
             $enrol = $DB->get_record('enrol', array('enrol' => 'notificationeabc', 'courseid' => $event->courseid));
@@ -177,13 +177,13 @@ class enrol_notificationeabc_observer
             }
 
             if (!empty($enrol) && $instanceenabled) {
-                $activeenrolalert = $enrol->customint3;
+                $activeenrolalert = $enrol->customint1;
             }
 
             if ($activeglobal == 1 && $activeenrolalert == 1) {
-                $notificationeabc->enviarmail($user, $course, 1);
+                $notificationeabc->send_email($user, $course, 1);
             } else if (!empty($enrol) && !empty($activeenrolalert) && $instanceenabled) {
-                $notificationeabc->enviarmail($user, $course, 1);
+                $notificationeabc->send_email($user, $course, 1);
             }
         }
     }

--- a/db/access.php
+++ b/db/access.php
@@ -38,4 +38,12 @@ $capabilities = array(
             'manager' => CAP_ALLOW,
         )
     ),
+    'enrol/notificationeabc:config' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        )
+    ),
 );

--- a/edit.php
+++ b/edit.php
@@ -80,7 +80,13 @@ if ($mform->is_cancelled()) {
 
         $instance->status = $data->status;
         $instance->name = $data->name;
-        $instance->customint1 = $data->customint1;
+
+        if (isset($data->customint1)) {
+            $instance->customint1 = $data->customint1;
+        } else {
+            $instance->customint1 = 0;
+        }
+
         if (isset($data->customint2)) {
             $instance->customint2 = $data->customint2;
         } else {
@@ -91,18 +97,6 @@ if ($mform->is_cancelled()) {
             $instance->customint3 = $data->customint3;
         } else {
             $instance->customint3 = 0;
-        }
-
-        if (isset($data->customint4)) {
-            $instance->customint4 = $data->customint4;
-        } else {
-            $instance->customint4 = 0;
-        }
-
-        if (isset($data->customint5)) {
-            $instance->customint5 = $data->customint5;
-        } else {
-            $instance->customint5 = 0;
         }
 
         $instance->customtext1 = $data->customtext1['text'];
@@ -124,8 +118,6 @@ if ($mform->is_cancelled()) {
             'customint1' => $data->customint1,
             'customint2' => $data->customint2,
             'customint3' => $data->customint3,
-            'customint4' => $data->customint4,
-            'customint5' => $data->customint5,
             'customtext1' => $data->customtext1['text'],
             'customtext2' => $data->customtext2['text'],
             'customtext3' => $data->customtext3['text'],

--- a/edit_form.php
+++ b/edit_form.php
@@ -49,30 +49,30 @@ class enrol_notificationeabc_edit_form extends moodleform
 
         $mform->addElement('header', 'header', get_string('pluginname', 'enrol_notificationeabc'));
         $mform->addElement('text', 'name', get_string('custominstancename', 'enrol'));
+        $mform->setType('name', PARAM_RAW);
 
-        $options = array(ENROL_INSTANCE_ENABLED => get_string('yes'),
-            ENROL_INSTANCE_DISABLED => get_string('no'));
+        $options = array(ENROL_INSTANCE_ENABLED => get_string('yes'), ENROL_INSTANCE_DISABLED => get_string('no'));
         $mform->addElement('select', 'status', get_string('status', 'enrol_notificationeabc'), $options);
 
         // Enrol notifications.
-        $mform->addElement('advcheckbox', 'customint3', get_string('activeenrolalert', 'enrol_notificationeabc'));
-        $mform->addHelpButton('customint3', 'activeenrolalert', 'enrol_notificationeabc');
+        $mform->addElement('advcheckbox', 'customint1', get_string('activeenrolalert', 'enrol_notificationeabc'));
+        $mform->addHelpButton('customint1', 'activeenrolalert', 'enrol_notificationeabc');
 
-        $mform->addElement('editor', 'customtext1', get_string('location', 'enrol_notificationeabc'), null);
+        $mform->addElement('editor', 'customtext1', get_string('enrolmessage', 'enrol_notificationeabc'), null);
         $mform->setType('customtext1', PARAM_RAW);
-        $mform->addHelpButton('customtext1', 'location', 'enrol_notificationeabc');
+        $mform->addHelpButton('customtext1', 'enrolmessage', 'enrol_notificationeabc');
 
         // Unenrol notifications.
-        $mform->addElement('advcheckbox', 'customint4', get_string('activeunenrolalert', 'enrol_notificationeabc'));
-        $mform->addHelpButton('customint4', 'activeunenrolalert', 'enrol_notificationeabc');
+        $mform->addElement('advcheckbox', 'customint2', get_string('activeunenrolalert', 'enrol_notificationeabc'));
+        $mform->addHelpButton('customint2', 'activeunenrolalert', 'enrol_notificationeabc');
 
         $mform->addElement('editor', 'customtext2', get_string('unenrolmessage', 'enrol_notificationeabc'), null);
         $mform->setType('customtext2', PARAM_RAW);
         $mform->addHelpButton('customtext2', 'unenrolmessage', 'enrol_notificationeabc');
 
         // Update enrolment notifications.
-        $mform->addElement('advcheckbox', 'customint5', get_string('activeenrolupdatedalert', 'enrol_notificationeabc'));
-        $mform->addHelpButton('customint5', 'activeenrolupdatedalert', 'enrol_notificationeabc');
+        $mform->addElement('advcheckbox', 'customint3', get_string('activeenrolupdatedalert', 'enrol_notificationeabc'));
+        $mform->addHelpButton('customint3', 'activeenrolupdatedalert', 'enrol_notificationeabc');
 
         $mform->addElement('editor', 'customtext3', get_string('updatedenrolmessage', 'enrol_notificationeabc'), null);
         $mform->setType('customtext3', PARAM_RAW);
@@ -81,9 +81,11 @@ class enrol_notificationeabc_edit_form extends moodleform
         // Email y nombre del remitente.
         $mform->addElement('text', 'customchar1', get_string('emailsender', 'enrol_notificationeabc'));
         $mform->addHelpButton('customchar1', 'emailsender', 'enrol_notificationeabc');
+        $mform->setType('customchar1', PARAM_RAW);
 
         $mform->addElement('text', 'customchar2', get_string('namesender', 'enrol_notificationeabc'));
         $mform->addHelpButton('customchar2', 'namesender', 'enrol_notificationeabc');
+        $mform->setType('customchar2', PARAM_RAW);
 
         $this->add_action_buttons(true, ($instance->id ? null : get_string('addinstance', 'enrol')));
 
@@ -103,9 +105,9 @@ class enrol_notificationeabc_edit_form extends moodleform
             $mform->setDefault('customtext3', array('text' => $instance->customtext3));
             $mform->setDefault('customchar1', $instance->customchar1);
             $mform->setDefault('customchar2', $instance->customchar2);
+            $mform->setDefault('customint1', $instance->customint1);
+            $mform->setDefault('customint2', $instance->customint2);
             $mform->setDefault('customint3', $instance->customint3);
-            $mform->setDefault('customint4', $instance->customint4);
-            $mform->setDefault('customint5', $instance->customint5);
             if (!empty($instance->name)) {
                 $mform->setDefault('name', $instance->name);
             } else {

--- a/lang/en/enrol_notificationeabc.php
+++ b/lang/en/enrol_notificationeabc.php
@@ -25,63 +25,68 @@
  * @author     Osvaldo Arriola <osvaldo@e-abclearning.com>
  */
 
-$string['filelockedmail'] = 'You has been enroled in {$a->fullname} ({$a->url})';
-$string['location'] = 'Message';
-$string['messageprovider:notificationeabc_enrolment'] = 'Enrol notification messages';
-$string['notificationeabc:manage'] = 'Manage notificationeabc';
-$string['pluginname'] = 'Enrol Notification';
+$string['activar_help'] = 'When activated will be verified by the immediate execution of cron later, users who were enrolled for the period specified above';
+$string['activar'] = 'Enable initial verification';
+$string['emailsender_help'] = 'By default set to take the email user support ';
+$string['emailsender'] = 'Email sender ';
+$string['failsend'] = 'WARNING: it has no been able to notify the {$a->username} user about his enrollment in the {$a->coursename} course'."\n";
+$string['fecha_help'] = 'Place the period for which you want to perform the first virificación';
+$string['fecha'] = 'Period for verification of users enrolled courses';
+$string['messageprovider:notificationeabc_enrolment'] = 'Enrol email notification messages';
+$string['namesender_help'] = 'By default it takes the name set to the user support';
+$string['namesender'] = 'Name sender ';
+$string['notificationeabc:config'] = 'Configure email notificationeabc instances';
+$string['notificationeabc:manage'] = 'Manage email notificationeabc';
 $string['pluginname_desc'] = 'Enrol notifications via mail';
-$string['location_help'] = 'Personalize the message that users will come to be enrolled. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
+$string['pluginname'] = 'Enrol Notification';
+$string['status'] = 'Active enrol email notification';
+$string['subject'] = 'Enrolment email notification';
+$string['succefullsend'] = 'The user {$a->username} has been notified about his enrollment in the {$a->coursename} course'."\n";
+
+// Unenrol notifications.
+$string['activeenrolalert'] = 'Active enrol alert';
+$string['activeenrolalert_help'] = 'Active enrol alert';
+$string['activarglobalenrolalert'] = 'Active global';
+$string['activarglobalenrolalert_help'] = 'Active enrol email notification for all site';
+$string['enrolmessage'] = 'Message';
+$string['enrolmessage_help'] = 'Personalize the message that users will come to be enrolled. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
 <pre>
 {COURSENAME} = course fullname
 {USERNAME} = username
-{NOMBRE} = firstname
-{APELLIDO} = lastname
+{FIRSTNAME} = firstname
+{LASTNAME} = lastname
 {URL} = course url
 </pre>';
-$string['fecha_help'] = 'Place the period for which you want to perform the first virificación';
-$string['fecha'] = 'Period for verification of users enrolled courses';
-$string['activar'] = 'Enable initial verification';
-$string['activar_help'] = 'When activated will be verified by the immediate execution of cron later, users who were enrolled for the period specified above';
-$string['activarglobal'] = 'Active global';
-$string['activarglobal_help'] = 'Active enrol notification for all site';
-$string['emailsender'] = 'Email sender ';
-$string['emailsender_help'] = 'By default set to take the email user support ';
-$string['namesender'] = 'Name sender ';
-$string['namesender_help'] = 'By default it takes the name set to the user support';
-$string['status'] = 'Active enrol notification';
-$string['subject'] = 'Enrolment notification';
-$string['activeenrolalert'] = 'Active enrol alert';
-$string['activeenrolalert_help'] = 'Active enrol alert';
+$string['enrolmessagedefault'] = 'You has been enroled in {$a->fullname} ({$a->url})';
+
 // Unenrol notifications.
-$string['activeunenrolalert'] = 'Active unenrol notifications';
+$string['activeunenrolalert'] = 'Active unenrol email notifications';
 $string['activeunenrolalert_help'] = 'Active unenrol alert';
 $string['activarglobalunenrolalert'] = 'Active global';
-$string['activarglobalunenrolalert_help'] = 'Active enrol notifications for all site';
+$string['activarglobalunenrolalert_help'] = 'Active enrol email notifications for all site';
 $string['unenrolmessage'] = 'Custom Message';
 $string['unenrolmessage_help'] = 'Personalize the message that users will come to be unenrolled. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
 <pre>
 {COURSENAME} = course fullname
 {USERNAME} = username
-{NOMBRE} = firstname
-{APELLIDO} = lastname
+{FIRSTNAME} = firstname
+{LASTNAME} = lastname
 {URL} = course url
 </pre>';
 $string['unenrolmessagedefault'] = 'You has been unenrolled from {$a->fullname} ({$a->url})';
+
 // Update enrol notifications.
-$string['activeenrolupdatedalert'] = 'Active update enrol notifications';
-$string['activeenrolupdatedalert_help'] = 'Active update enrol notifications';
+$string['activeenrolupdatedalert'] = 'Active update enrol email notifications';
+$string['activeenrolupdatedalert_help'] = 'Active update enrol email notifications';
 $string['activarglobalenrolupdated'] = 'Active global';
-$string['activarglobalenrolupdated_help'] = 'Active enrol updated notifications for all site';
+$string['activarglobalenrolupdated_help'] = 'Active enrol updated email notifications for all site';
 $string['updatedenrolmessage'] = 'Custom message';
 $string['updatedenrolmessage_help'] = 'Personalize the message that users will come to be updated. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
 <pre>
 {COURSENAME} = course fullname
 {USERNAME} = username
-{NOMBRE} = firstname
-{APELLIDO} = lastname
+{FIRSTNAME} = firstname
+{LASTNAME} = lastname
 {URL} = course url
 </pre>';
 $string['updatedenrolmessagedefault'] = 'Your enrolment from {$a->fullname} has been updated ({$a->url})';
-$string['succefullsend'] = 'The user {$a->username} has been notified about his enrollment in the {$a->coursename} course'."\n";
-$string['failsend'] = 'WARNING: it has no been able to notify the {$a->username} user about his enrollment in the {$a->coursename} course'."\n";

--- a/lang/es/enrol_notificationeabc.php
+++ b/lang/es/enrol_notificationeabc.php
@@ -25,8 +25,8 @@
  * @author     Osvaldo Arriola <osvaldo@e-abclearning.com>
  */
 
-$string['filelockedmail'] = 'Ud ha sido matriculado en el curso {$a->fullname} ({$a->url})';
-$string['location'] = 'Mensaje personalizado';
+$string['enrolmessagedefault'] = 'Ud ha sido matriculado en el curso {$a->fullname} ({$a->url})';
+$string['enrolmessage'] = 'Mensaje personalizado';
 $string['messageprovider:notificationeabc_enrolment'] = 'Enrol notification messages';
 $string['notificationeabc:manage'] = 'Gestionar notificaciones de matriculación';
 $string['pluginname'] = 'Notificación de Matriculación';
@@ -35,16 +35,16 @@ $string['location_help'] = 'Personalice el mensaje que le llegará a los usuario
 <pre>
 {COURSENAME} = Nombre completo del curso
 {USERNAME} = Nombre de usuario
-{NOMBRE} = Nombre
-{APELLIDO} = Apellido
+{FIRSTNAME} = Nombre
+{LASTNAME} = Apellido
 {URL} = Url del curso
 </pre>';
 $string['fecha_help'] = 'Coloque el periodo por el cual desea que se realice la virificación inicial de usuarios matriculados';
 $string['fecha'] = 'Período para realizar la verificación de usuarios que se matricularon a cursos';
 $string['activar'] = 'Activar verificación inicial';
 $string['activar_help'] = 'Al activarse se verificará, mediante la ejecucion del cron inmediata posterior, los usuarios que fueron matriculados en el periodo establecido arriba';
-$string['activarglobal'] = 'Activar para todo el sitio';
-$string['activarglobal_help'] = 'Activa la notificacion de matriculacion para todo los cursos';
+$string['activarglobalenrolalert'] = 'Activar para todo el sitio';
+$string['activarglobalenrolalert_help'] = 'Activa la notificacion de matriculacion para todo los cursos';
 $string['emailsender'] = 'Email del remitente ';
 $string['emailsender_help'] = 'Por defecto toma el email configurado como el usuario de soporte ';
 $string['namesender'] = 'Nombre del remitente ';
@@ -63,8 +63,8 @@ $string['unenrolmessage_help'] = 'Personalice el mensaje que le llegará a los u
 <pre>
 {COURSENAME} = Nombre completo del curso
 {USERNAME} = Nombre de usuario
-{NOMBRE} = Nombre
-{APELLIDO} = Apellido
+{FIRSTNAME} = Nombre
+{LASTNAME} = Apellido
 {URL} = Url del curso
 </pre>';
 $string['unenrolmessagedefault'] = 'Ud ha sido desmatriculado del curso {$a->fullname} ({$a->url})';
@@ -78,8 +78,8 @@ $string['updatedenrolmessage_help'] = 'Personalice el mensaje que le llegará a 
 <pre>
 {COURSENAME} = Nombre completo del curso
 {USERNAME} = Nombre de usuario
-{NOMBRE} = Nombre
-{APELLIDO} = Apellido
+{FIRSTNAME} = Nombre
+{LASTNAME} = Apellido
 {URL} = Url del curso
 </pre>';
 $string['updatedenrolmessagedefault'] = 'Su matriculacion en el curso {$a->fullname} ha sido actualizada ({$a->url})';

--- a/settings.php
+++ b/settings.php
@@ -42,8 +42,8 @@ if ($ADMIN->fulltree) {
     );
     $settings->add(new admin_setting_configcheckbox(
         'enrol_notificationeabc/activarglobal',
-        get_string('activarglobal', 'enrol_notificationeabc'),
-        get_string('activarglobal_help', 'enrol_notificationeabc'),
+        get_string('activarglobalenrolalert', 'enrol_notificationeabc'),
+        get_string('activarglobalenrolalert_help', 'enrol_notificationeabc'),
         '')
     );
     $settings->add(new admin_setting_heading(

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017111700;
+$plugin->version   = 2018022001;
 $plugin->requires  = 2016120503;
 $plugin->component = 'enrol_notificationeabc';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
I made some changes in order to drop warnings and make the code better and more uniform.
I AM NOT SURE ABOUT THE FIXES I ADDED.
It seems to me that the code works fine but I have to test it better.
Please review and merge this PR.

Among fixes:
- no more warnings (with debugger set to developer)
- customint1 and customint2 were dropped
- customint3, customint4 and customint5 were renamed to customint1, customint2 and customint3
- added notificationeabc:config capability to override public function can_hide_show_instance($instance)
- overridden public function can_hide_show_instance($instance)
- icons in Administration > Course administration > Users > Enrolment methods are now homogeneous with the other enrolment plugin
- few (not all) variables renamed to corresponding name in english
- strings key made homogeneous
- some lang strings slightly changed
- increased version number