### PR TITLE
Support additional name placeholders in English

### DIFF
--- a/lang/en/enrol_notificationeabc.php
+++ b/lang/en/enrol_notificationeabc.php
@@ -35,8 +35,8 @@ $string['location_help'] = 'Personalize the message that users will come to be e
 <pre>
 {COURSENAME} = course fullname
 {USERNAME} = username
-{NOMBRE} = firstname
-{APELLIDO} = lastname
+{NOMBRE} or {FIRSTNAME} = firstname
+{APELLIDO} or {LASTNAME} = lastname
 {URL} = course url
 </pre>';
 $string['fecha_help'] = 'Place the period for which you want to perform the first virificación';
@@ -63,8 +63,8 @@ $string['unenrolmessage_help'] = 'Personalize the message that users will come t
 <pre>
 {COURSENAME} = course fullname
 {USERNAME} = username
-{NOMBRE} = firstname
-{APELLIDO} = lastname
+{NOMBRE} or {FIRSTNAME} = firstname
+{APELLIDO} or {LASTNAME} = lastname
 {URL} = course url
 </pre>';
 $string['unenrolmessagedefault'] = 'You has been unenrolled from {$a->fullname} ({$a->url})';
@@ -78,8 +78,8 @@ $string['updatedenrolmessage_help'] = 'Personalize the message that users will c
 <pre>
 {COURSENAME} = course fullname
 {USERNAME} = username
-{NOMBRE} = firstname
-{APELLIDO} = lastname
+{NOMBRE} or {FIRSTNAME} = firstname
+{APELLIDO} or {LASTNAME} = lastname
 {URL} = course url
 </pre>';
 $string['updatedenrolmessagedefault'] = 'Your enrolment from {$a->fullname} has been updated ({$a->url})';

--- a/lang/es/enrol_notificationeabc.php
+++ b/lang/es/enrol_notificationeabc.php
@@ -35,8 +35,8 @@ $string['location_help'] = 'Personalice el mensaje que le llegará a los usuario
 <pre>
 {COURSENAME} = Nombre completo del curso
 {USERNAME} = Nombre de usuario
-{NOMBRE} = Nombre
-{APELLIDO} = Apellido
+{NOMBRE} or {FIRSTNAME} = Nombre
+{APELLIDO} or {LASTNAME} = Apellido
 {URL} = Url del curso
 </pre>';
 $string['fecha_help'] = 'Coloque el periodo por el cual desea que se realice la virificación inicial de usuarios matriculados';
@@ -63,8 +63,8 @@ $string['unenrolmessage_help'] = 'Personalice el mensaje que le llegará a los u
 <pre>
 {COURSENAME} = Nombre completo del curso
 {USERNAME} = Nombre de usuario
-{NOMBRE} = Nombre
-{APELLIDO} = Apellido
+{NOMBRE} or {FIRSTNAME} = Nombre
+{APELLIDO} or {LASTNAME} = Apellido
 {URL} = Url del curso
 </pre>';
 $string['unenrolmessagedefault'] = 'Ud ha sido desmatriculado del curso {$a->fullname} ({$a->url})';
@@ -78,8 +78,8 @@ $string['updatedenrolmessage_help'] = 'Personalice el mensaje que le llegará a 
 <pre>
 {COURSENAME} = Nombre completo del curso
 {USERNAME} = Nombre de usuario
-{NOMBRE} = Nombre
-{APELLIDO} = Apellido
+{NOMBRE} or {FIRSTNAME} = Nombre
+{APELLIDO} or {LASTNAME} = Apellido
 {URL} = Url del curso
 </pre>';
 $string['updatedenrolmessagedefault'] = 'Su matriculacion en el curso {$a->fullname} ha sido actualizada ({$a->url})';

--- a/lib.php
+++ b/lib.php
@@ -178,7 +178,9 @@ class enrol_notificationeabc_plugin extends enrol_plugin
         $m = str_replace('{COURSENAME}', $course->fullname, $m);
         $m = str_replace('{USERNAME}', $user->username, $m);
         $m = str_replace('{NOMBRE}', $user->firstname, $m);
+        $m = str_replace('{FIRSTNAME}', $user->firstname, $m); // Supports also EN placeholder name
         $m = str_replace('{APELLIDO}', $user->lastname, $m);
+        $m = str_replace('{LASTNAME}', $user->lastname, $m); // Supports also EN placeholder name
         $m = str_replace('{URL}', $url, $m);
         return $m;
     }


### PR DESCRIPTION
The current name placeholders "NOMBRE" and "APELLIDO" are in Spanish which might be a little bit difficult for non-Spanish site admins. 

I would like to propose supporting additional name placeholders "FIRSTNAME" and "LASTNAME" that are in English. The concept is to be transparent to sites using the existing plugin versions, so the change is to add extra attempts to replace the new placeholders instead of replacing the existing placeholders.