### PR TITLE
Enhance default message logic and setting page layout

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -54,6 +54,7 @@ class enrol_notificationeabc_edit_form extends moodleform
         $options = array(ENROL_INSTANCE_ENABLED => get_string('yes'),
             ENROL_INSTANCE_DISABLED => get_string('no'));
         $mform->addElement('select', 'status', get_string('status', 'enrol_notificationeabc'), $options);
+        $mform->addHelpButton('status', 'status', 'enrol_notificationeabc');
 
         // Enrol notifications.
         $mform->addElement('advcheckbox', 'customint1', get_string('activeenrolalert', 'enrol_notificationeabc'));

--- a/lang/en/enrol_notificationeabc.php
+++ b/lang/en/enrol_notificationeabc.php
@@ -25,12 +25,12 @@
  * @author     Osvaldo Arriola <osvaldo@e-abclearning.com>
  */
 
-$string['filelockedmail'] = 'You has been enroled in {$a->fullname} ({$a->url})';
+$string['filelockedmail'] = 'You have been enroled in {COURSENAME} ({URL})';
 $string['location'] = 'Message';
 $string['messageprovider:notificationeabc_enrolment'] = 'Enrol notification messages';
 $string['notificationeabc:manage'] = 'Manage notificationeabc';
 $string['pluginname'] = 'Enrol Notification';
-$string['pluginname_desc'] = 'Enrol notifications via mail';
+$string['pluginname_desc'] = 'Enrol notifications via email. Configure the site level default values here. The settings could be overwritten per course by adding Enrol Notification as an Enrolment method.';
 $string['location_help'] = 'Personalize the message that users will come to be enrolled. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
 <pre>
 {COURSENAME} = course fullname
@@ -43,19 +43,25 @@ $string['fecha_help'] = 'Place the period for which you want to perform the firs
 $string['fecha'] = 'Period for verification of users enrolled courses';
 $string['activar'] = 'Enable initial verification';
 $string['activar_help'] = 'When activated will be verified by the immediate execution of cron later, users who were enrolled for the period specified above';
+$string['activarglobal_heading'] = 'Enrol notifications';
 $string['activarglobal'] = 'Active global';
 $string['activarglobal_help'] = 'Active enrol notification for all site';
+$string['common_settings_heading'] = 'Common settings';
 $string['emailsender'] = 'Email sender ';
 $string['emailsender_help'] = 'By default set to take the email user support ';
 $string['namesender'] = 'Name sender ';
 $string['namesender_help'] = 'By default it takes the name set to the user support';
 $string['status'] = 'Active enrol notification';
+$string['status_help'] = 'Set to "Yes" to enable notification on the course or overwrite the custom message defined in site level setting (if enabled).
+
+If enrol notification is enabled in site level, set to "No" will not disable the notifications but follow the site level setting.';
 $string['subject'] = 'Enrolment notification';
 $string['activeenrolalert'] = 'Active enrol alert';
 $string['activeenrolalert_help'] = 'Active enrol alert';
 // Unenrol notifications.
 $string['activeunenrolalert'] = 'Active unenrol notifications';
 $string['activeunenrolalert_help'] = 'Active unenrol alert';
+$string['activarglobalunenrolalert_heading'] = 'Unenrol notifications';
 $string['activarglobalunenrolalert'] = 'Active global';
 $string['activarglobalunenrolalert_help'] = 'Active enrol notifications for all site';
 $string['unenrolmessage'] = 'Custom Message';
@@ -67,10 +73,11 @@ $string['unenrolmessage_help'] = 'Personalize the message that users will come t
 {APELLIDO} = lastname
 {URL} = course url
 </pre>';
-$string['unenrolmessagedefault'] = 'You has been unenrolled from {$a->fullname} ({$a->url})';
+$string['unenrolmessagedefault'] = 'You have been unenrolled from {COURSENAME} ({URL})';
 // Update enrol notifications.
 $string['activeenrolupdatedalert'] = 'Active update enrol notifications';
 $string['activeenrolupdatedalert_help'] = 'Active update enrol notifications';
+$string['activarglobalenrolupdated_heading'] = 'Update enrol notifications';
 $string['activarglobalenrolupdated'] = 'Active global';
 $string['activarglobalenrolupdated_help'] = 'Active enrol updated notifications for all site';
 $string['updatedenrolmessage'] = 'Custom message';
@@ -82,6 +89,6 @@ $string['updatedenrolmessage_help'] = 'Personalize the message that users will c
 {APELLIDO} = lastname
 {URL} = course url
 </pre>';
-$string['updatedenrolmessagedefault'] = 'Your enrolment from {$a->fullname} has been updated ({$a->url})';
+$string['updatedenrolmessagedefault'] = 'Your enrolment to {COURSENAME} has been updated ({URL})';
 $string['succefullsend'] = 'The user {$a->username} has been notified about his enrollment in the {$a->coursename} course'."\n";
 $string['failsend'] = 'WARNING: it has no been able to notify the {$a->username} user about his enrollment in the {$a->coursename} course'."\n";

--- a/lang/es/enrol_notificationeabc.php
+++ b/lang/es/enrol_notificationeabc.php
@@ -25,7 +25,7 @@
  * @author     Osvaldo Arriola <osvaldo@e-abclearning.com>
  */
 
-$string['filelockedmail'] = 'Ud ha sido matriculado en el curso {$a->fullname} ({$a->url})';
+$string['filelockedmail'] = 'Ud ha sido matriculado en el curso {COURSENAME} ({URL})';
 $string['location'] = 'Mensaje personalizado';
 $string['messageprovider:notificationeabc_enrolment'] = 'Enrol notification messages';
 $string['notificationeabc:manage'] = 'Gestionar notificaciones de matriculación';
@@ -67,7 +67,7 @@ $string['unenrolmessage_help'] = 'Personalice el mensaje que le llegará a los u
 {APELLIDO} = Apellido
 {URL} = Url del curso
 </pre>';
-$string['unenrolmessagedefault'] = 'Ud ha sido desmatriculado del curso {$a->fullname} ({$a->url})';
+$string['unenrolmessagedefault'] = 'Ud ha sido desmatriculado del curso {COURSENAME} ({URL})';
 // Aviso de actualizacion de matriculacion.
 $string['activeenrolupdatedalert'] = 'Activar aviso de actualizacion de matriculacion';
 $string['activeenrolupdatedalert_help'] = 'Activar aviso de actualizacion de matriculacion';
@@ -82,6 +82,6 @@ $string['updatedenrolmessage_help'] = 'Personalice el mensaje que le llegará a 
 {APELLIDO} = Apellido
 {URL} = Url del curso
 </pre>';
-$string['updatedenrolmessagedefault'] = 'Su matriculacion en el curso {$a->fullname} ha sido actualizada ({$a->url})';
+$string['updatedenrolmessagedefault'] = 'Su matriculacion en el curso {COURSENAME} ha sido actualizada ({URL})';
 $string['succefullsend'] = 'Se notifico al usuario {$a->username} sobre su matriculación en el curso {$a->coursename}'. "\n";
 $string['failsend'] = 'ATENCION: No se pudo notificar al usuario {$a->username} sobre su matriculación en el curso {$a->coursename}'."\n";

--- a/lib.php
+++ b/lib.php
@@ -75,13 +75,13 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                     if (!empty($texto)) {
                         $mensaje = $this->process_mensaje($enrol->customtext1, $user, $course);
                     } else {
-                        $mensaje = get_string("filelockedmail", "enrol_notificationeabc", $course);
+                        $mensaje = $this->process_mensaje(get_string('filelockedmail', 'enrol_notificationeabc'), $user, $course);
                     }
 
                 } else if (!empty($activeglobalenrol) && !empty($plainmensajeenrol)) {
                     $mensaje = $this->process_mensaje($mensajeenrol, $user, $course);
                 } else {
-                    $mensaje = get_string("filelockedmail", "enrol_notificationeabc", $course);
+                    $mensaje = $this->process_mensaje(get_string('filelockedmail', 'enrol_notificationeabc'), $user, $course);
                 }
                 break;
             case 2:
@@ -91,13 +91,13 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                     if (!empty($texto)) {
                         $mensaje = $this->process_mensaje($enrol->customtext2, $user, $course);
                     } else {
-                        $mensaje = get_string("unenrolmessagedefault", "enrol_notificationeabc", $course);
+                        $mensaje = $this->process_mensaje(get_string('unenrolmessagedefault', 'enrol_notificationeabc'), $user, $course);
                     }
 
                 } else if (!empty($activarglobalunenrolalert) && !empty($plainmensajeunenrol)) {
                     $mensaje = $this->process_mensaje($mensajeunenrol, $user, $course);
                 } else {
-                    $mensaje = get_string("unenrolmessagedefault", "enrol_notificationeabc", $course);
+                    $mensaje = $this->process_mensaje(get_string('unenrolmessagedefault', 'enrol_notificationeabc'), $user, $course);
                 }
                 break;
             case 3:
@@ -107,13 +107,13 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                     if (!empty($texto)) {
                         $mensaje = $this->process_mensaje($enrol->customtext3, $user, $course);
                     } else {
-                        $mensaje = get_string("updatedenrolmessagedefault", "enrol_notificationeabc", $course);
+                        $mensaje = $this->process_mensaje(get_string('updatedenrolmessagedefault', 'enrol_notificationeabc'), $user, $course);
                     }
 
                 } else if (!empty($activarglobalenrolupdated) && !empty($plainmensajeupdateenrol)) {
                     $mensaje = $this->process_mensaje($mensajeupdateenrol, $user, $course);
                 } else {
-                    $mensaje = get_string("updatedenrolmessagedefault", "enrol_notificationeabc", $course);
+                    $mensaje = $this->process_mensaje(get_string('updatedenrolmessagedefault', 'enrol_notificationeabc'), $user, $course);
                 }
                 break;
 

--- a/settings.php
+++ b/settings.php
@@ -40,23 +40,29 @@ if ($ADMIN->fulltree) {
     //     '',
     //     '1')
     // );
-    $settings->add(new admin_setting_configcheckbox(
-        'enrol_notificationeabc/activarglobal',
-        get_string('activarglobal', 'enrol_notificationeabc'),
-        get_string('activarglobal_help', 'enrol_notificationeabc'),
-        '')
-    );
     $settings->add(new admin_setting_heading(
         'enrol_notificationeabc_settings',
         '',
         get_string('pluginname_desc', 'enrol_notificationeabc'),
         '')
     );
+    $settings->add(new admin_setting_heading(
+        'enrol_notificationeabc/activarglobalheading',
+        get_string('activarglobal_heading', 'enrol_notificationeabc'),
+        '',
+        '')
+    );
+    $settings->add(new admin_setting_configcheckbox(
+        'enrol_notificationeabc/activarglobal',
+        get_string('activarglobal', 'enrol_notificationeabc'),
+        get_string('activarglobal_help', 'enrol_notificationeabc'),
+        '')
+    );
     $settings->add(new admin_setting_confightmleditor(
         'enrol_notificationeabc/location',
         get_string('location', 'enrol_notificationeabc'),
         get_string('location_help', 'enrol_notificationeabc'),
-        '')
+        get_string('filelockedmail', 'enrol_notificationeabc'))
     );
 
     // Unenrol notification.
@@ -67,6 +73,12 @@ if ($ADMIN->fulltree) {
     //     '',
     //     '1')
     // );
+    $settings->add(new admin_setting_heading(
+        'enrol_notificationeabc/activarglobalunenrolalertheading',
+        get_string('activarglobalunenrolalert_heading', 'enrol_notificationeabc'),
+        '',
+        '')
+    );
     $settings->add(new admin_setting_configcheckbox(
         'enrol_notificationeabc/activarglobalunenrolalert',
         get_string('activarglobalunenrolalert', 'enrol_notificationeabc'),
@@ -77,7 +89,7 @@ if ($ADMIN->fulltree) {
         'enrol_notificationeabc/unenrolmessage',
         get_string('unenrolmessage', 'enrol_notificationeabc'),
         get_string('unenrolmessage_help', 'enrol_notificationeabc'),
-        '')
+        get_string('unenrolmessagedefault', 'enrol_notificationeabc'))
     );
 
     // Update enrol notification.
@@ -88,6 +100,12 @@ if ($ADMIN->fulltree) {
     //     '',
     //     '1')
     // );
+    $settings->add(new admin_setting_heading(
+        'enrol_notificationeabc/activarglobalenrolupdatedheading',
+        get_string('activarglobalenrolupdated_heading', 'enrol_notificationeabc'),
+        '',
+        '')
+    );
     $settings->add(new admin_setting_configcheckbox(
         'enrol_notificationeabc/activarglobalenrolupdated',
         get_string('activarglobalenrolupdated', 'enrol_notificationeabc'),
@@ -98,6 +116,12 @@ if ($ADMIN->fulltree) {
         'enrol_notificationeabc/updatedenrolmessage',
         get_string('updatedenrolmessage', 'enrol_notificationeabc'),
         get_string('updatedenrolmessage_help', 'enrol_notificationeabc'),
+        get_string('updatedenrolmessagedefault', 'enrol_notificationeabc'))
+    );
+    $settings->add(new admin_setting_heading(
+        'enrol_notificationeabc/commonsettingsheading',
+        get_string('common_settings_heading', 'enrol_notificationeabc'),
+        '',
         '')
     );
     $settings->add(new admin_setting_configtext(


### PR DESCRIPTION
I would like to propose below changes to the setting pages layout:
1. Add section headers to the setting page to make it clearer on different type of the notifications
2. Display the default values in the settings page
3. Add a help button in the course setting page for the status dropdown to describe the usage in more details

Since the default message values are using different placeholders that site admin could use, I suggest to also revise the logic to align the placeholder values for better maintenance and display.

Note: Sorry that I am not familiar on Spanish so the corresponding translations are not added to the ES translation file...