### PR TITLE
Expose email subject as configurable settings

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -105,6 +105,9 @@ if ($mform->is_cancelled()) {
             $instance->customint5 = 0;
         }
 
+        $instance->customsubject1 = $data->customsubject1;
+        $instance->customsubject2 = $data->customsubject2;
+        $instance->customsubject3 = $data->customsubject3;
         $instance->customtext1 = $data->customtext1['text'];
         $instance->customtext2 = $data->customtext2['text'];
         $instance->customtext3 = $data->customtext3['text'];
@@ -126,6 +129,9 @@ if ($mform->is_cancelled()) {
             'customint3' => $data->customint3,
             'customint4' => $data->customint4,
             'customint5' => $data->customint5,
+            'customsubject1' => $data->customsubject1,
+            'customsubject2' => $data->customsubject2,
+            'customsubject3' => $data->customsubject3,
             'customtext1' => $data->customtext1['text'],
             'customtext2' => $data->customtext2['text'],
             'customtext3' => $data->customtext3['text'],

--- a/lang/en/enrol_notificationeabc.php
+++ b/lang/en/enrol_notificationeabc.php
@@ -26,6 +26,8 @@
  */
 
 $string['filelockedmail'] = 'You has been enroled in {$a->fullname} ({$a->url})';
+$string['enrolsubject'] = 'Custom Subject';
+$string['enrolsubject_help'] = 'Personalize the email subject for enrol notifications';
 $string['location'] = 'Message';
 $string['messageprovider:notificationeabc_enrolment'] = 'Enrol notification messages';
 $string['notificationeabc:manage'] = 'Manage notificationeabc';
@@ -58,6 +60,8 @@ $string['activeunenrolalert'] = 'Active unenrol notifications';
 $string['activeunenrolalert_help'] = 'Active unenrol alert';
 $string['activarglobalunenrolalert'] = 'Active global';
 $string['activarglobalunenrolalert_help'] = 'Active enrol notifications for all site';
+$string['unenrolsubject'] = 'Custom Subject';
+$string['unenrolsubject_help'] = 'Personalize the email subject for unenrol notifications';
 $string['unenrolmessage'] = 'Custom Message';
 $string['unenrolmessage_help'] = 'Personalize the message that users will come to be unenrolled. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
 <pre>
@@ -73,6 +77,8 @@ $string['activeenrolupdatedalert'] = 'Active update enrol notifications';
 $string['activeenrolupdatedalert_help'] = 'Active update enrol notifications';
 $string['activarglobalenrolupdated'] = 'Active global';
 $string['activarglobalenrolupdated_help'] = 'Active enrol updated notifications for all site';
+$string['updatedenrolsubject'] = 'Custom Subject';
+$string['updatedenrolsubject_help'] = 'Personalize the email subject for update enrol notifications';
 $string['updatedenrolmessage'] = 'Custom message';
 $string['updatedenrolmessage_help'] = 'Personalize the message that users will come to be updated. This field accepts the following markers which then will be replaced by the corresponding values ​​dynamically
 <pre>

--- a/lib.php
+++ b/lib.php
@@ -88,9 +88,9 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                 }
                 
                 if (!empty($enrolsubject)) {
-                    $emailsubject = $this->process_mensaje($enrolsubject, $user, $course);
+                    $emailsubject = $this->process_subject($enrolsubject, $user, $course);
                 } else {
-                    $emailsubject = get_string('subject', 'enrol_notificationeabc');
+                    $emailsubject = $this->process_subject(get_string('subject', 'enrol_notificationeabc'), $user, $course);
                 }
                 break;
             case 2:
@@ -110,9 +110,9 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                 }
                 
                 if (!empty($unenrolsubject)) {
-                    $emailsubject = $this->process_mensaje($unenrolsubject, $user, $course);
+                    $emailsubject = $this->process_subject($unenrolsubject, $user, $course);
                 } else {
-                    $emailsubject = get_string('subject', 'enrol_notificationeabc');
+                    $emailsubject = $this->process_subject(get_string('subject', 'enrol_notificationeabc'), $user, $course);
                 }
                 break;
             case 3:
@@ -132,9 +132,9 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                 }
                 
                 if (!empty($updatedenrolsubject)) {
-                    $emailsubject = $this->process_mensaje($updatedenrolsubject, $user, $course);
+                    $emailsubject = $this->process_subject($updatedenrolsubject, $user, $course);
                 } else {
-                    $emailsubject = get_string('subject', 'enrol_notificationeabc');
+                    $emailsubject = $this->process_subject(get_string('subject', 'enrol_notificationeabc'), $user, $course);
                 }
                 break;
 
@@ -184,6 +184,26 @@ class enrol_notificationeabc_plugin extends enrol_plugin
         }
     } // End of function.
 
+    // Common function to process placeholders in content
+    /**
+     * Proccess message method
+     * @param String $mensaje el mensaje en bruto
+     * @param stdClass $user instancia usuario
+     * @param stdClass $course instancia curso
+     * @return String el mensaje procesado
+     */
+    public function process_placeholders($mensaje, stdClass $user, stdClass $course) {
+        global $CFG;
+        $m = $mensaje;
+        $url = new moodle_url($CFG->wwwroot . '/course/view.php', array('id' => $course->id));
+        $m = str_replace('{COURSENAME}', $course->fullname, $m);
+        $m = str_replace('{USERNAME}', $user->username, $m);
+        $m = str_replace('{NOMBRE}', $user->firstname, $m);
+        $m = str_replace('{APELLIDO}', $user->lastname, $m);
+        $m = str_replace('{URL}', $url, $m);
+        return $m;
+    }
+
     // Procesa el mensaje para aceptar marcadores.
     /**
      * Proccess message method
@@ -195,12 +215,25 @@ class enrol_notificationeabc_plugin extends enrol_plugin
     public function process_mensaje($mensaje, stdClass $user, stdClass $course) {
         global $CFG;
         $m = $mensaje;
-        $url = new moodle_url($CFG->wwwroot . '/course/view.php', array('id' => $course->id));
-        $m = str_replace('{COURSENAME}', $course->fullname, $m);
-        $m = str_replace('{USERNAME}', $user->username, $m);
-        $m = str_replace('{NOMBRE}', $user->firstname, $m);
-        $m = str_replace('{APELLIDO}', $user->lastname, $m);
-        $m = str_replace('{URL}', $url, $m);
+        $m = $this->process_placeholders($m, $user, $course);
+        $m = format_text($m);
+        return $m;
+    }
+
+
+    // Process email subject
+    /**
+     * Proccess message method
+     * @param String $mensaje el mensaje en bruto
+     * @param stdClass $user instancia usuario
+     * @param stdClass $course instancia curso
+     * @return String el mensaje procesado
+     */
+    public function process_subject($mensaje, stdClass $user, stdClass $course) {
+        global $CFG;
+        $m = $mensaje;
+        $m = $this->process_placeholders($m, $user, $course);
+        $m = format_string($m);
         return $m;
     }
 

--- a/lib.php
+++ b/lib.php
@@ -196,7 +196,7 @@ class enrol_notificationeabc_plugin extends enrol_plugin
         global $CFG;
         $m = $mensaje;
         $url = new moodle_url($CFG->wwwroot . '/course/view.php', array('id' => $course->id));
-        $m = str_replace('{COURSENAME}', $course->fullname, $m);
+        $m = str_replace('{COURSENAME}', format_string($course->fullname), $m);
         $m = str_replace('{USERNAME}', $user->username, $m);
         $m = str_replace('{NOMBRE}', $user->firstname, $m);
         $m = str_replace('{APELLIDO}', $user->lastname, $m);

--- a/lib.php
+++ b/lib.php
@@ -66,6 +66,9 @@ class enrol_notificationeabc_plugin extends enrol_plugin
         $plainmensajeunenrol = strip_tags($mensajeunenrol);
         $mensajeupdateenrol = $this->get_config('updatedenrolmessage');
         $plainmensajeupdateenrol = strip_tags($mensajeupdateenrol);
+        $enrolsubject = $this->get_config('enrolsubject');
+        $unenrolsubject = $this->get_config('unenrolsubject');
+        $updatedenrolmessage = $this->get_config('updatedenrolmessage');
 
         switch ((int)$type) {
             case 1:
@@ -83,6 +86,12 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                 } else {
                     $mensaje = get_string("filelockedmail", "enrol_notificationeabc", $course);
                 }
+                
+                if (!empty($enrolsubject)) {
+                    $emailsubject = $this->process_mensaje($enrolsubject, $user, $course);
+                } else {
+                    $emailsubject = get_string('subject', 'enrol_notificationeabc');
+                }
                 break;
             case 2:
 
@@ -99,6 +108,12 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                 } else {
                     $mensaje = get_string("unenrolmessagedefault", "enrol_notificationeabc", $course);
                 }
+                
+                if (!empty($unenrolsubject)) {
+                    $emailsubject = $this->process_mensaje($unenrolsubject, $user, $course);
+                } else {
+                    $emailsubject = get_string('subject', 'enrol_notificationeabc');
+                }
                 break;
             case 3:
 
@@ -114,6 +129,12 @@ class enrol_notificationeabc_plugin extends enrol_plugin
                     $mensaje = $this->process_mensaje($mensajeupdateenrol, $user, $course);
                 } else {
                     $mensaje = get_string("updatedenrolmessagedefault", "enrol_notificationeabc", $course);
+                }
+                
+                if (!empty($updatedenrolsubject)) {
+                    $emailsubject = $this->process_mensaje($updatedenrolsubject, $user, $course);
+                } else {
+                    $emailsubject = get_string('subject', 'enrol_notificationeabc');
                 }
                 break;
 
@@ -146,7 +167,7 @@ class enrol_notificationeabc_plugin extends enrol_plugin
         $eventdata->name = 'notificationeabc_enrolment';
         $eventdata->userfrom = $sender;
         $eventdata->userto = $user->id;
-        $eventdata->subject = get_string('subject', 'enrol_notificationeabc');
+        $eventdata->subject = $emailsubject;
         $eventdata->fullmessage = '';
         $eventdata->fullmessageformat = FORMAT_HTML;
         $eventdata->fullmessagehtml = $mensaje;
@@ -219,6 +240,9 @@ class enrol_notificationeabc_plugin extends enrol_plugin
         $fields['customint5'] = $this->get_config('activeenrolupdatedalert');
         $fields['customchar1'] = $this->get_config('emailsender');
         $fields['customchar2'] = $this->get_config('namesender');
+        $fields['customsubject1'] = $this->get_config('enrolsubject');
+        $fields['customsubject2'] = $this->get_config('unenrolsubject');
+        $fields['customsubject3'] = $this->get_config('updatedenrolsubject');
 
         return $fields;
     }

--- a/settings.php
+++ b/settings.php
@@ -52,6 +52,12 @@ if ($ADMIN->fulltree) {
         get_string('pluginname_desc', 'enrol_notificationeabc'),
         '')
     );
+    $settings->add(new admin_setting_configtext(
+        'enrol_notificationeabc/enrolsubject',
+        get_string('enrolsubject', 'enrol_notificationeabc'),
+        get_string('enrolsubject_help', 'enrol_notificationeabc'),
+        get_string('subject', 'enrol_notificationeabc'))
+    );
     $settings->add(new admin_setting_confightmleditor(
         'enrol_notificationeabc/location',
         get_string('location', 'enrol_notificationeabc'),
@@ -73,6 +79,12 @@ if ($ADMIN->fulltree) {
         get_string('activarglobalunenrolalert_help', 'enrol_notificationeabc'),
         '')
     );
+    $settings->add(new admin_setting_configtext(
+        'enrol_notificationeabc/unenrolsubject',
+        get_string('unenrolsubject', 'enrol_notificationeabc'),
+        get_string('unenrolsubject_help', 'enrol_notificationeabc'),
+        get_string('subject', 'enrol_notificationeabc'))
+    );
     $settings->add(new admin_setting_confightmleditor(
         'enrol_notificationeabc/unenrolmessage',
         get_string('unenrolmessage', 'enrol_notificationeabc'),
@@ -93,6 +105,12 @@ if ($ADMIN->fulltree) {
         get_string('activarglobalenrolupdated', 'enrol_notificationeabc'),
         get_string('activarglobalenrolupdated_help', 'enrol_notificationeabc'),
         '')
+    );
+    $settings->add(new admin_setting_configtext(
+        'enrol_notificationeabc/updatedenrolsubject',
+        get_string('updatedenrolsubject', 'enrol_notificationeabc'),
+        get_string('updatedenrolsubject_help', 'enrol_notificationeabc'),
+        get_string('subject', 'enrol_notificationeabc'))
     );
     $settings->add(new admin_setting_confightmleditor(
         'enrol_notificationeabc/updatedenrolmessage',


### PR DESCRIPTION
The email subject is now always fixed to "Enrol Notification". This is to make the email subjects of all 3 notification types to be configurable to allow flexibility.